### PR TITLE
chore: distinguish sdp token from any non ws token

### DIFF
--- a/src/lines/candidate-line.ts
+++ b/src/lines/candidate-line.ts
@@ -1,4 +1,4 @@
-import { NUM, REST, TOKEN } from '../regex-helpers';
+import { NUM, REST, ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -31,7 +31,7 @@ export class CandidateLine extends Line {
   private static ICE_CHARS = `[a-zA-Z0-9+/]+`;
 
   private static regex = new RegExp(
-    `^candidate:(${this.ICE_CHARS}) (${NUM}) (${TOKEN}) (${NUM}) (${TOKEN}) (${NUM}) typ (${TOKEN})(?: raddr (${TOKEN}))?(?: rport (${NUM}))?(?: (${REST}))?`
+    `^candidate:(${this.ICE_CHARS}) (${NUM}) (${ANY_NON_WS}) (${NUM}) (${ANY_NON_WS}) (${NUM}) typ (${ANY_NON_WS})(?: raddr (${ANY_NON_WS}))?(?: rport (${NUM}))?(?: (${REST}))?`
   );
 
   /**

--- a/src/lines/connection-line.ts
+++ b/src/lines/connection-line.ts
@@ -1,4 +1,4 @@
-import { TOKEN } from '../regex-helpers';
+import { ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -14,7 +14,7 @@ export class ConnectionLine extends Line {
 
   ipAddr: string;
 
-  private static regex = new RegExp(`^(${TOKEN}) (${TOKEN}) (${TOKEN})`);
+  private static regex = new RegExp(`^(${ANY_NON_WS}) (${ANY_NON_WS}) (${ANY_NON_WS})`);
 
   /**
    * Create a ConnectionLine from the given values.

--- a/src/lines/extmap-line.ts
+++ b/src/lines/extmap-line.ts
@@ -1,4 +1,4 @@
-import { NUM, REST, TOKEN } from '../regex-helpers';
+import { NUM, REST, ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -19,7 +19,7 @@ export class ExtMapLine extends Line {
   private static EXTMAP_DIRECTION = `sendonly|recvonly|sendrecv|inactive`;
 
   private static regex = new RegExp(
-    `^extmap:(${NUM})(?:/(${this.EXTMAP_DIRECTION}))? (${TOKEN})(?: (${REST}))?`
+    `^extmap:(${NUM})(?:/(${this.EXTMAP_DIRECTION}))? (${ANY_NON_WS})(?: (${REST}))?`
   );
 
   /**

--- a/src/lines/ice-pwd-line.ts
+++ b/src/lines/ice-pwd-line.ts
@@ -1,4 +1,4 @@
-import { TOKEN } from '../regex-helpers';
+import { ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -10,7 +10,7 @@ import { Line } from './line';
 export class IcePwdLine extends Line {
   pwd: string;
 
-  private static regex = new RegExp(`^ice-pwd:(${TOKEN})$`);
+  private static regex = new RegExp(`^ice-pwd:(${ANY_NON_WS})$`);
 
   /**
    * Create an IcePwdLine from the given values.

--- a/src/lines/ice-ufrag-line.ts
+++ b/src/lines/ice-ufrag-line.ts
@@ -1,4 +1,4 @@
-import { TOKEN } from '../regex-helpers';
+import { ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -10,7 +10,7 @@ import { Line } from './line';
 export class IceUfragLine extends Line {
   ufrag: string;
 
-  private static regex = new RegExp(`^ice-ufrag:(${TOKEN})$`);
+  private static regex = new RegExp(`^ice-ufrag:(${ANY_NON_WS})$`);
 
   /**
    * Create an IceUfragLine from the given values.

--- a/src/lines/media-line.ts
+++ b/src/lines/media-line.ts
@@ -1,4 +1,4 @@
-import { NUM, REST, TOKEN } from '../regex-helpers';
+import { NUM, REST, ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 export type MediaType = 'audio' | 'video' | 'application';
@@ -20,7 +20,7 @@ export class MediaLine extends Line {
 
   private static MEDIA_TYPE = 'audio|video|application';
 
-  private static regex = new RegExp(`^(${this.MEDIA_TYPE}) (${NUM}) (${TOKEN}) (${REST})`);
+  private static regex = new RegExp(`^(${this.MEDIA_TYPE}) (${NUM}) (${ANY_NON_WS}) (${REST})`);
 
   /**
    * Create a new MediaLine from the given values.

--- a/src/lines/mid-line.ts
+++ b/src/lines/mid-line.ts
@@ -1,4 +1,4 @@
-import { TOKEN } from '../regex-helpers';
+import { ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -10,7 +10,7 @@ import { Line } from './line';
 export class MidLine extends Line {
   mid: string;
 
-  private static regex = new RegExp(`^mid:(${TOKEN})$`);
+  private static regex = new RegExp(`^mid:(${ANY_NON_WS})$`);
 
   /**
    * Create a MidLine from the given values.

--- a/src/lines/origin-line.ts
+++ b/src/lines/origin-line.ts
@@ -1,4 +1,4 @@
-import { NUM, TOKEN } from '../regex-helpers';
+import { NUM, ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -22,7 +22,7 @@ export class OriginLine extends Line {
   ipAddr: string;
 
   private static regex = new RegExp(
-    `^(${TOKEN}) (${TOKEN}) (${NUM}) (${TOKEN}) (${TOKEN}) (${TOKEN})`
+    `^(${ANY_NON_WS}) (${ANY_NON_WS}) (${NUM}) (${ANY_NON_WS}) (${ANY_NON_WS}) (${ANY_NON_WS})`
   );
 
   /**

--- a/src/lines/simulcast-line.ts
+++ b/src/lines/simulcast-line.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
-import { TOKEN } from '../regex-helpers';
+import { ANY_NON_WS } from '../regex-helpers';
 import { Line } from './line';
 
 /**
@@ -132,7 +132,7 @@ export class SimulcastLine extends Line {
   recvLayers: SimulcastLayerList;
 
   private static regex = new RegExp(
-    `^simulcast:(send|recv) (${TOKEN})(?: (send|recv) (${TOKEN}))?`
+    `^simulcast:(send|recv) (${ANY_NON_WS})(?: (send|recv) (${ANY_NON_WS}))?`
   );
 
   /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,7 +28,13 @@ import { SimulcastLine } from './lines/simulcast-line';
 import { TimingLine } from './lines/timing-line';
 import { UnknownLine } from './lines/unknown-line';
 import { VersionLine } from './lines/version-line';
-import { ApplicationMediaDescription, AvMediaDescription, MediaDescription, Sdp, SdpBlock } from './model';
+import {
+  ApplicationMediaDescription,
+  AvMediaDescription,
+  MediaDescription,
+  Sdp,
+  SdpBlock,
+} from './model';
 
 type Parser = (line: string) => Line | undefined;
 type LineType =

--- a/src/regex-helpers.ts
+++ b/src/regex-helpers.ts
@@ -1,7 +1,9 @@
 // Any consecutive string of digits
 export const NUM = '\\d+';
+// SDP token (see 'token'/'token-char' in https://www.rfc-editor.org/rfc/rfc8866.html#name-sdp-grammar)
+export const SDP_TOKEN = "[!#$%&'*+\\-.^_`{|}~a-zA-Z0-9]+";
 // Any consecutive non-whitespace token
-export const TOKEN = '\\S+';
+export const ANY_NON_WS = '\\S+';
 // A single whitespace
 export const SP = '\\s';
 // 0 or more whitespace chars


### PR DESCRIPTION
Split out some work from https://github.com/webex/ts-sdp/pull/3 to separate an 'sdp token' (defined by the spec) from 'any non-whitespace token'.