### PR TITLE
feat: make mids member inside of BundleGroupLine accessible

### DIFF
--- a/src/lines/bundle-group-line.ts
+++ b/src/lines/bundle-group-line.ts
@@ -8,7 +8,7 @@ import { Line } from './line';
  * a=group:BUNDLE 0 1 2
  */
 export class BundleGroupLine extends Line {
-  private mids: Array<string>;
+  mids: Array<string>;
 
   private static regex = new RegExp(`^group:BUNDLE (${REST})`);
 


### PR DESCRIPTION
I ran into this when trying to do some munging of the sdp.  Since these lines should enable munging, I think it makes sense to expose these members for such a purpose.  Perhaps worth a broader change across the other line types, but just fixing this one for now.  We can see what other needs come up.