### PR TITLE
fix: handling of SDPs without any rtpmap lines

### DIFF
--- a/src/model/codec-info.ts
+++ b/src/model/codec-info.ts
@@ -80,9 +80,11 @@ export class CodecInfo implements SdpBlock {
   toLines(): Array<Line> {
     const lines = [];
     // First the RtpMap
-    lines.push(
-      new RtpMapLine(this.pt, this.name as string, this.clockRate as number, this.encodingParams)
-    );
+    if (this.name && this.clockRate) {
+      lines.push(
+        new RtpMapLine(this.pt, this.name as string, this.clockRate as number, this.encodingParams)
+      );
+    }
     // Now all RtcpFb
     this.feedback.forEach((fb) => {
       lines.push(new RtcpFbLine(this.pt, fb));

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -156,4 +156,13 @@ describe('parsing', () => {
       new ConnectionLine('IN', 'IP6', '2a02:c7f:60d6:2600:4157:2f9c:198b:80a3')
     );
   });
+
+  it('should handle media sections without any rtpmap lines', () => {
+    expect.hasAssertions();
+    const sdpWithoutRtpmapLines = fs.readFileSync('./src/sdp-corpus/without_rtpmap.sdp', 'utf-8');
+    const parsed = parse(sdpWithoutRtpmapLines);
+    const sdpAfterProcessing = parsed.toString();
+
+    compareSdps(sdpAfterProcessing, sdpWithoutRtpmapLines);
+  });
 });

--- a/src/sdp-corpus/without_rtpmap.sdp
+++ b/src/sdp-corpus/without_rtpmap.sdp
@@ -1,0 +1,15 @@
+v=0
+o=BroadWorks 16647125 1678951083182 IN IP4 139.177.70.17
+s=-
+c=IN IP4 139.177.70.17
+t=0 0
+a=ice-lite
+m=audio 42520 UDP/TLS/RTP/SAVPF 0
+a=ice-ufrag:tuJU
+a=ice-pwd:3yjQ1o6l7xjrFei8xCPx3N89
+a=candidate:mse 1 UDP 2130706431 139.177.70.17 42520 typ host
+a=candidate:mse 2 UDP 2130706430 139.177.70.17 42521 typ host
+a=fingerprint:sha-256 2C:4C:94:3F:13:58:64:5C:57:3D:3B:88:3F:BB:D3:1D:20:1E:0F:49:D0:EA:8C:EF:EB:F6:E1:B4:21:46:8D:2A
+a=setup:actpass
+a=rtcp-mux
+a=ssrc:2037740846 cname:Xp9fodVPUgfz1DLl


### PR DESCRIPTION
Issue found by customers using the calling project. Sometimes their SDPs don't have any rtpmap lines. When we parse the SDP and convert it back to string, the ts-sdp library is adding lines like this:
```
a=rtpmap:0 undefined/undefined
```
which then causes browser to reject the SDP.

jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-413001