### PR TITLE
fix: allow comma special case in fmtp line

### DIFF
--- a/src/lines/fmtp-line.spec.ts
+++ b/src/lines/fmtp-line.spec.ts
@@ -19,6 +19,15 @@ describe('parseFmtpParams', () => {
     );
     expect(Object.fromEntries(fmtpParams)).toStrictEqual(expectedValue);
   });
+  it('special case', async () => {
+    expect.hasAssertions();
+    let fmtpParams = parseFmtpParams('a=fmtp:121 0/5');
+    expect(Object.fromEntries(fmtpParams)).toStrictEqual({ '0/5': undefined }); // chrome RED
+    fmtpParams = parseFmtpParams('a=fmtp:121 0-5');
+    expect(Object.fromEntries(fmtpParams)).toStrictEqual({ '0-5': undefined }); // firefox RED
+    fmtpParams = parseFmtpParams('a=fmtp:126 0-15,16');
+    expect(Object.fromEntries(fmtpParams)).toStrictEqual({ '0-15,16': undefined }); // SPARK-440089
+  });
   it('exceptional case', async () => {
     expect.hasAssertions();
     expect(() => {

--- a/src/lines/fmtp-line.ts
+++ b/src/lines/fmtp-line.ts
@@ -31,7 +31,8 @@ export function parseFmtpParams(fmtpParams: string) {
   const fmtpObj = new Map<string, string | undefined>();
 
   // compatible with RED，such as `a=fmtp:121 0/5` in chrome and `a=fmtp:121 0-5` in firefox, which can {@link https://www.rfc-editor.org/rfc/rfc2198}
-  if (/^\d+([/-]\d+)+$/.test(fmtpParams)) {
+  // also compatible with special case `a=fmtp:126 0-15,16`, see https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-440089.
+  if (/^\d+([,/-]\d+)+$/.test(fmtpParams)) {
     fmtpObj.set(fmtpParams, undefined);
     return fmtpObj;
   }


### PR DESCRIPTION
This PR makes `FmtpLine` compatible with the special case described in https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-440089. It also adds some unit tests to test the other special cases.