### PR TITLE
feat: add disableTwcc helper function

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -67,6 +67,7 @@
     "trackingid",
     "transcoding",
     "transpiled",
+    "twcc",
     "typedoc",
     "ufrag",
     "ulpfec",

--- a/src/munge.ts
+++ b/src/munge.ts
@@ -33,16 +33,16 @@ export function disableRtcpFbValue(sdpOrAv: Sdp | AvMediaDescription, rtcpFbValu
 }
 
 /**
- * Disable REMB from all media blocks in the given SDP.
+ * Disable REMB from the media blocks in the given SDP or audio/video media description.
  *
- * @param sdp - The SDP from which to filter REMB.
+ * @param sdpOrAv - The {@link Sdp} or {@link AvMediaDescription} from which to filter REMB.
  */
-export function disableRemb(sdp: Sdp) {
-  disableRtcpFbValue(sdp, 'goog-remb');
+export function disableRemb(sdpOrAv: Sdp | AvMediaDescription) {
+  disableRtcpFbValue(sdpOrAv, 'goog-remb');
 }
 
 /**
- * Disable REMB from all media blocks in the given SDP.
+ * Disable TWCC from the media blocks in the given SDP or audio/video media description.
  *
  * @param sdpOrAv - The {@link Sdp} or {@link AvMediaDescription} from which to filter TWCC.
  */

--- a/src/munge.ts
+++ b/src/munge.ts
@@ -17,13 +17,14 @@
 import { AvMediaDescription, CodecInfo, MediaDescription, Sdp } from './model';
 
 /**
- * Disable an rtcp-fb value from all media blocks in the given SDP.
+ * Disable an rtcp-fb value from the media blocks in the given SDP or audio/video media description.
  *
- * @param sdp - The SDP from which to filter an rtcp-fb value.
+ * @param sdpOrAv - The {@link Sdp} or {@link AvMediaDescription} from which to filter an rtcp-fb value.
  * @param rtcpFbValue - The rtcp-fb value to filter.
  */
-export function disableRtcpFbValue(sdp: Sdp, rtcpFbValue: string) {
-  sdp.avMedia.forEach((media: AvMediaDescription) => {
+export function disableRtcpFbValue(sdpOrAv: Sdp | AvMediaDescription, rtcpFbValue: string) {
+  const mediaDescriptions = sdpOrAv instanceof Sdp ? sdpOrAv.avMedia : [sdpOrAv];
+  mediaDescriptions.forEach((media: AvMediaDescription) => {
     media.codecs.forEach((codec: CodecInfo) => {
       // eslint-disable-next-line no-param-reassign
       codec.feedback = codec.feedback.filter((fb) => fb !== rtcpFbValue);
@@ -38,6 +39,15 @@ export function disableRtcpFbValue(sdp: Sdp, rtcpFbValue: string) {
  */
 export function disableRemb(sdp: Sdp) {
   disableRtcpFbValue(sdp, 'goog-remb');
+}
+
+/**
+ * Disable REMB from all media blocks in the given SDP.
+ *
+ * @param sdpOrAv - The {@link Sdp} or {@link AvMediaDescription} from which to filter TWCC.
+ */
+export function disableTwcc(sdpOrAv: Sdp | AvMediaDescription) {
+  disableRtcpFbValue(sdpOrAv, 'transport-cc');
 }
 
 /**

--- a/src/sdp-corpus/offer_with_rtcp_feedback.sdp
+++ b/src/sdp-corpus/offer_with_rtcp_feedback.sdp
@@ -1,0 +1,283 @@
+v=0
+o=- 4527418419436041501 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0 1 2 3 4
+a=extmap-allow-mixed
+a=msid-semantic: WMS
+m=video 9 UDP/TLS/RTP/SAVPF 102 103 104 105 106 107 108 109 127 125 39 40 112 113
+c=IN IP4 0.0.0.0
+b=TIAS:20000000
+a=ice-ufrag:WGE2
+a=ice-pwd:LmviYSZI3K7FZUba9r8b0tnS
+a=ice-options:trickle
+a=candidate:dummy1 1 udp 1 0.0.0.0 9 typ host
+a=candidate:dummy2 1 tcp 2 0.0.0.0 9 typ host
+a=candidate:dummy3 1 udp 3 0.0.0.0 9 typ relay
+a=fingerprint:sha-256 72:E3:DC:BF:9D:05:BE:9E:59:14:C5:3F:16:7C:F1:2E:79:0A:9D:9D:F7:08:6F:12:DA:C7:CE:F5:6A:6D:02:02
+a=setup:actpass
+a=mid:0
+a=rtcp-mux
+a=extmap:1 urn:ietf:params:rtp-hdrext:toffset
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:3 urn:3gpp:video-orientation
+a=extmap:4 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space
+a=extmap:9 http://www.webrtc.org/experiments/rtp-hdrext/video-layers-allocation00
+a=sendrecv
+a=rtpmap:102 H264/90000
+a=rtcp-fb:102 goog-remb
+a=rtcp-fb:102 transport-cc
+a=rtcp-fb:102 ccm fir
+a=rtcp-fb:102 nack
+a=rtcp-fb:102 nack pli
+a=fmtp:102 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=42001f
+a=rtpmap:103 rtx/90000
+a=fmtp:103 apt=102
+a=rtpmap:104 H264/90000
+a=rtcp-fb:104 goog-remb
+a=rtcp-fb:104 transport-cc
+a=rtcp-fb:104 ccm fir
+a=rtcp-fb:104 nack
+a=rtcp-fb:104 nack pli
+a=fmtp:104 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=0;profile-level-id=42001f
+a=rtpmap:105 rtx/90000
+a=fmtp:105 apt=104
+a=rtpmap:106 H264/90000
+a=rtcp-fb:106 goog-remb
+a=rtcp-fb:106 transport-cc
+a=rtcp-fb:106 ccm fir
+a=rtcp-fb:106 nack
+a=rtcp-fb:106 nack pli
+a=fmtp:106 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=42e01f
+a=rtpmap:107 rtx/90000
+a=fmtp:107 apt=106
+a=rtpmap:108 H264/90000
+a=rtcp-fb:108 goog-remb
+a=rtcp-fb:108 transport-cc
+a=rtcp-fb:108 ccm fir
+a=rtcp-fb:108 nack
+a=rtcp-fb:108 nack pli
+a=fmtp:108 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=0;profile-level-id=42e01f
+a=rtpmap:109 rtx/90000
+a=fmtp:109 apt=108
+a=rtpmap:127 H264/90000
+a=rtcp-fb:127 goog-remb
+a=rtcp-fb:127 transport-cc
+a=rtcp-fb:127 ccm fir
+a=rtcp-fb:127 nack
+a=rtcp-fb:127 nack pli
+a=fmtp:127 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=4d001f
+a=rtpmap:125 rtx/90000
+a=fmtp:125 apt=127
+a=rtpmap:39 H264/90000
+a=rtcp-fb:39 goog-remb
+a=rtcp-fb:39 transport-cc
+a=rtcp-fb:39 ccm fir
+a=rtcp-fb:39 nack
+a=rtcp-fb:39 nack pli
+a=fmtp:39 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=0;profile-level-id=4d001f
+a=rtpmap:40 rtx/90000
+a=fmtp:40 apt=39
+a=rtpmap:112 H264/90000
+a=rtcp-fb:112 goog-remb
+a=rtcp-fb:112 transport-cc
+a=rtcp-fb:112 ccm fir
+a=rtcp-fb:112 nack
+a=rtcp-fb:112 nack pli
+a=fmtp:112 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=64001f
+a=rtpmap:113 rtx/90000
+a=fmtp:113 apt=112
+a=ssrc:4041180815 cname:3207704834-cname
+a=ssrc:4041180815 msid:- 7df7633e-0ab7-40ab-821f-c7f8854b79c8
+a=ssrc:3692841381 cname:3207704834-cname
+a=ssrc:3692841381 msid:- 7df7633e-0ab7-40ab-821f-c7f8854b79c8
+a=ssrc:3407205327 cname:3207704834-cname
+a=ssrc:3407205327 msid:- 7df7633e-0ab7-40ab-821f-c7f8854b79c8
+a=ssrc:4112470980 cname:3207704834-cname
+a=ssrc:4112470980 msid:- 7df7633e-0ab7-40ab-821f-c7f8854b79c8
+a=ssrc:3207704834 cname:3207704834-cname
+a=ssrc:3207704834 msid:- 7df7633e-0ab7-40ab-821f-c7f8854b79c8
+a=ssrc:1862345290 cname:3207704834-cname
+a=ssrc:1862345290 msid:- 7df7633e-0ab7-40ab-821f-c7f8854b79c8
+a=ssrc:4041180815 fmtp:* max-fs=240
+a=ssrc:3407205327 fmtp:* max-fs=2304
+a=ssrc:3207704834 fmtp:* max-fs=8160
+a=ssrc-group:FID 4041180815 3692841381
+a=ssrc-group:FID 3407205327 4112470980
+a=ssrc-group:FID 3207704834 1862345290
+a=ssrc-group:SIM 4041180815 3407205327 3207704834
+a=rtcp:9 IN IP4 0.0.0.0
+a=msid:- 7df7633e-0ab7-40ab-821f-c7f8854b79c8
+a=rtcp-rsize
+a=jmp:v1
+a=jmp-source:0 csi=614376449
+a=jmp-stream-id-mode:SSRC
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+c=IN IP4 0.0.0.0
+b=TIAS:20000000
+a=ice-ufrag:WGE2
+a=ice-pwd:LmviYSZI3K7FZUba9r8b0tnS
+a=ice-options:trickle
+a=candidate:dummy1 1 udp 1 0.0.0.0 9 typ host
+a=candidate:dummy2 1 tcp 2 0.0.0.0 9 typ host
+a=candidate:dummy3 1 udp 3 0.0.0.0 9 typ relay
+a=fingerprint:sha-256 72:E3:DC:BF:9D:05:BE:9E:59:14:C5:3F:16:7C:F1:2E:79:0A:9D:9D:F7:08:6F:12:DA:C7:CE:F5:6A:6D:02:02
+a=setup:actpass
+a=mid:1
+a=rtcp-mux
+a=extmap:14 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:4 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=sendrecv
+a=rtpmap:111 opus/48000/2
+a=rtcp-fb:111 transport-cc
+a=fmtp:111 minptime=10;useinbandfec=1
+a=ssrc:1950135206 cname:1950135206-cname
+a=ssrc:1950135206 msid:- 1931893f-eb80-4940-8b6f-168c4102ae1d
+a=rtcp:9 IN IP4 0.0.0.0
+a=msid:- 1931893f-eb80-4940-8b6f-168c4102ae1d
+a=jmp:v1
+a=jmp-source:1 csi=614376448
+a=jmp-stream-id-mode:SSRC
+m=video 9 UDP/TLS/RTP/SAVPF 102 103 104 105 106 107 108 109 127 125 39 40 112 113
+c=IN IP4 0.0.0.0
+b=TIAS:20000000
+a=ice-ufrag:WGE2
+a=ice-pwd:LmviYSZI3K7FZUba9r8b0tnS
+a=ice-options:trickle
+a=candidate:dummy1 1 udp 1 0.0.0.0 9 typ host
+a=candidate:dummy2 1 tcp 2 0.0.0.0 9 typ host
+a=candidate:dummy3 1 udp 3 0.0.0.0 9 typ relay
+a=fingerprint:sha-256 72:E3:DC:BF:9D:05:BE:9E:59:14:C5:3F:16:7C:F1:2E:79:0A:9D:9D:F7:08:6F:12:DA:C7:CE:F5:6A:6D:02:02
+a=setup:actpass
+a=mid:2
+a=rtcp-mux
+a=content:slides
+a=extmap:1 urn:ietf:params:rtp-hdrext:toffset
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:3 urn:3gpp:video-orientation
+a=extmap:4 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space
+a=sendrecv
+a=rtpmap:102 H264/90000
+a=rtcp-fb:102 goog-remb
+a=rtcp-fb:102 transport-cc
+a=rtcp-fb:102 ccm fir
+a=rtcp-fb:102 nack
+a=rtcp-fb:102 nack pli
+a=fmtp:102 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=42001f
+a=rtpmap:103 rtx/90000
+a=fmtp:103 apt=102
+a=rtpmap:104 H264/90000
+a=rtcp-fb:104 goog-remb
+a=rtcp-fb:104 transport-cc
+a=rtcp-fb:104 ccm fir
+a=rtcp-fb:104 nack
+a=rtcp-fb:104 nack pli
+a=fmtp:104 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=0;profile-level-id=42001f
+a=rtpmap:105 rtx/90000
+a=fmtp:105 apt=104
+a=rtpmap:106 H264/90000
+a=rtcp-fb:106 goog-remb
+a=rtcp-fb:106 transport-cc
+a=rtcp-fb:106 ccm fir
+a=rtcp-fb:106 nack
+a=rtcp-fb:106 nack pli
+a=fmtp:106 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=42e01f
+a=rtpmap:107 rtx/90000
+a=fmtp:107 apt=106
+a=rtpmap:108 H264/90000
+a=rtcp-fb:108 goog-remb
+a=rtcp-fb:108 transport-cc
+a=rtcp-fb:108 ccm fir
+a=rtcp-fb:108 nack
+a=rtcp-fb:108 nack pli
+a=fmtp:108 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=0;profile-level-id=42e01f
+a=rtpmap:109 rtx/90000
+a=fmtp:109 apt=108
+a=rtpmap:127 H264/90000
+a=rtcp-fb:127 goog-remb
+a=rtcp-fb:127 transport-cc
+a=rtcp-fb:127 ccm fir
+a=rtcp-fb:127 nack
+a=rtcp-fb:127 nack pli
+a=fmtp:127 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=4d001f
+a=rtpmap:125 rtx/90000
+a=fmtp:125 apt=127
+a=rtpmap:39 H264/90000
+a=rtcp-fb:39 goog-remb
+a=rtcp-fb:39 transport-cc
+a=rtcp-fb:39 ccm fir
+a=rtcp-fb:39 nack
+a=rtcp-fb:39 nack pli
+a=fmtp:39 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=0;profile-level-id=4d001f
+a=rtpmap:40 rtx/90000
+a=fmtp:40 apt=39
+a=rtpmap:112 H264/90000
+a=rtcp-fb:112 goog-remb
+a=rtcp-fb:112 transport-cc
+a=rtcp-fb:112 ccm fir
+a=rtcp-fb:112 nack
+a=rtcp-fb:112 nack pli
+a=fmtp:112 level-asymmetry-allowed=1;max-fs=8160;max-mbps=244800;packetization-mode=1;profile-level-id=64001f
+a=rtpmap:113 rtx/90000
+a=fmtp:113 apt=112
+a=ssrc:1601294813 cname:1601294813-cname
+a=ssrc:1601294813 msid:- e4ee89d3-a43a-4e5e-b177-5ff60c26a558
+a=ssrc:3724904697 cname:1601294813-cname
+a=ssrc:3724904697 msid:- e4ee89d3-a43a-4e5e-b177-5ff60c26a558
+a=ssrc-group:FID 1601294813 3724904697
+a=rtcp:9 IN IP4 0.0.0.0
+a=msid:- e4ee89d3-a43a-4e5e-b177-5ff60c26a558
+a=rtcp-rsize
+a=jmp:v1
+a=jmp-source:2 csi=2130765313
+a=jmp-stream-id-mode:SSRC
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+c=IN IP4 0.0.0.0
+b=TIAS:20000000
+a=ice-ufrag:WGE2
+a=ice-pwd:LmviYSZI3K7FZUba9r8b0tnS
+a=ice-options:trickle
+a=candidate:dummy1 1 udp 1 0.0.0.0 9 typ host
+a=candidate:dummy2 1 tcp 2 0.0.0.0 9 typ host
+a=candidate:dummy3 1 udp 3 0.0.0.0 9 typ relay
+a=fingerprint:sha-256 72:E3:DC:BF:9D:05:BE:9E:59:14:C5:3F:16:7C:F1:2E:79:0A:9D:9D:F7:08:6F:12:DA:C7:CE:F5:6A:6D:02:02
+a=setup:actpass
+a=mid:3
+a=rtcp-mux
+a=content:slides
+a=extmap:14 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:4 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=sendrecv
+a=rtpmap:111 opus/48000/2
+a=rtcp-fb:111 transport-cc
+a=fmtp:111 minptime=10;useinbandfec=1
+a=ssrc:3695427635 cname:3695427635-cname
+a=ssrc:3695427635 msid:- 9bac9e61-e8fc-4bd4-9d41-bf171305d9f2
+a=rtcp:9 IN IP4 0.0.0.0
+a=msid:- 9bac9e61-e8fc-4bd4-9d41-bf171305d9f2
+a=jmp:v1
+a=jmp-source:3 csi=2130765312
+a=jmp-stream-id-mode:SSRC
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=ice-ufrag:WGE2
+a=ice-pwd:LmviYSZI3K7FZUba9r8b0tnS
+a=ice-options:trickle
+a=candidate:dummy1 1 udp 1 0.0.0.0 9 typ host
+a=candidate:dummy2 1 tcp 2 0.0.0.0 9 typ host
+a=candidate:dummy3 1 udp 3 0.0.0.0 9 typ relay
+a=fingerprint:sha-256 72:E3:DC:BF:9D:05:BE:9E:59:14:C5:3F:16:7C:F1:2E:79:0A:9D:9D:F7:08:6F:12:DA:C7:CE:F5:6A:6D:02:02
+a=setup:actpass
+a=mid:4
+a=sctp-port:5000
+a=max-message-size:262144


### PR DESCRIPTION
This pr adds a new function disableTwcc to and also modifies the existing function disableRtcpFbValue in munge.ts.
With this change we'll be able to disable audio twcc, which impacts probing and bandwidth estimation according to our test.