### PR TITLE
feat: add new removeLineByKey method as a PoC

### DIFF
--- a/src/model/media-description.ts
+++ b/src/model/media-description.ts
@@ -126,4 +126,48 @@ export abstract class MediaDescription implements SdpBlock {
     // If it didn't match anything else, see if IceInfo wants it.
     return this.iceInfo.addLine(line);
   }
+
+  /**
+   * Remove a line from the media description by key.
+   *
+   * @param key - The key of the line to be removed.
+   * @returns True if a line was removed; false otherwise.
+   */
+  removeLineByKey(key: keyof MediaDescription): boolean {
+    if (key === 'bandwidth' && this.bandwidth) {
+      delete this.bandwidth;
+      return true;
+    }
+    if (key === 'mid' && this.mid) {
+      delete this.mid;
+      return true;
+    }
+    if (key === 'fingerprint' && this.fingerprint) {
+      delete this.fingerprint;
+      return true;
+    }
+    if (key === 'setup' && this.setup) {
+      delete this.setup;
+      return true;
+    }
+    if (key === 'connection' && this.connection) {
+      delete this.connection;
+      return true;
+    }
+    if (key === 'content' && this.content) {
+      delete this.content;
+      return true;
+    }
+
+    // The 'otherLines' key would represent any other line in otherLines.
+    if (key === 'otherLines') {
+      // Here we can implement logic to handle removal from otherLines if needed.
+
+      // For now, we can just return false to indicate no action taken.
+      return false;
+    }
+
+    // If the key is not found, return false.
+    return false;
+  }
 }


### PR DESCRIPTION
Hello team, I would like to share my Proof of Concept (PoC) regarding the use of `MediaDescription` method. Currently, the method only allows adding lines to the Session Description Protocol (SDP). However, I encountered a situation where I needed to delete certain lines from the SDP. To address this, I propose a new method that will allow deleting lines from the SDP. My idea is to use specific key strings to avoid any typos or errors. This method will ideally be used in TypeScript projects, but it will also be able to handle strange key values. I would appreciate your thoughts and feedback on this. Let's discuss if this can potentially be useful for our project.

Example how we now working in WCME with deleting properties: 
mediaDescription.simulcast = undefined;